### PR TITLE
Add support for named expression parameters

### DIFF
--- a/SharpEdif/Extension.cs
+++ b/SharpEdif/Extension.cs
@@ -23,7 +23,7 @@ namespace SharpEdif.User
             return rdPtr->runData.ExampleString == testString;
         }
 
-        [Expression("Get string", "GetStr$(")]
+        [Expression("Get string", "GetStr$(", new[]{"String to get"})]
         public static string ExpressionExample1(LPRDATA* rdPtr, string test)
         {
             return test;

--- a/SharpEdif/SDK/API.cs
+++ b/SharpEdif/SDK/API.cs
@@ -181,8 +181,6 @@ namespace SharpEdif
         {
             SharpEdif.AllocConsole();
             Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
-            SharpEdif.LoadACEs();
-
             return 0;
         }
 

--- a/SharpEdif/SDK/API.cs
+++ b/SharpEdif/SDK/API.cs
@@ -662,6 +662,9 @@ namespace SharpEdif
                                               byte* strBuf, short maxLen)
         {
             Utils.Log("GetExpressionParam got called");
+#if EDITTIME
+            Utils.CopyStringToMemoryA(SDK.expressionParameterNames[code][param], strBuf, maxLen);
+#endif
         }
 
         [DllExport("GetRunObjectSurface",CallingConvention.StdCall)]

--- a/SharpEdif/SDK/SDK.cs
+++ b/SharpEdif/SDK/SDK.cs
@@ -10,6 +10,10 @@ namespace SharpEdif
 {
     public static unsafe class SDK
     {
+        static SDK()
+        {
+            SharpEdif.LoadACEs();
+        }
         public const string extName = Extension.ExtensionName;
         public const string extAuthor = Extension.ExtensionAuthor;
         public const string extCopyright = Extension.ExtensionCopyright;

--- a/SharpEdif/SDK/SharpEdif.cs
+++ b/SharpEdif/SDK/SharpEdif.cs
@@ -30,16 +30,21 @@ namespace SharpEdif
 
     public class ACEAttribute : Attribute
     {
-      
+        public string MenuName { get; }
+        public string EditorName { get; }
+        public string[] ParameterNames { get; }
+
         public ACEAttribute(string menuName, string editorName)
+            : this(menuName, editorName, Array.Empty<string>())
         {
-           
-        }
-        public ACEAttribute(string menuName, string editorName,string[] parameterNames)
-        {
-            
         }
 
+        public ACEAttribute(string menuName, string editorName, string[] parameterNames)
+        {
+            MenuName = menuName;
+            EditorName = editorName;
+            ParameterNames = parameterNames ?? Array.Empty<string>();
+        }
     }
     public class ConditionAttribute : ACEAttribute
     {
@@ -62,6 +67,10 @@ namespace SharpEdif
     public class ExpressionAttribute : ACEAttribute
     {
         public ExpressionAttribute(string menuName, string editorName) : base(menuName, editorName)
+        {
+        }
+
+        public ExpressionAttribute(string menuName, string editorName, string[] parameterNames) : base(menuName, editorName, parameterNames)
         {
         }
     }


### PR DESCRIPTION
## Summary
- allow ACE attributes to carry parameter names
- return expression parameter names via GetExpressionParam
- populate expression parameter names during build

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.7.2 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68982e1e9e24832ca64957cc0ae0e3f4